### PR TITLE
Add 3.3.5a compatibility

### DIFF
--- a/Glass.toc
+++ b/Glass.toc
@@ -1,4 +1,4 @@
-## Interface: 90001
+## Interface: 30300
 ## Plain Title: Glass
 ## Author: mixxorz
 ## Version: 1.8.0
@@ -29,6 +29,7 @@ libs\LibEasing\LibEasing.lua
 # Glass
 Glass\init.lua
 Glass\constants.lua
+Glass\compat.lua
 Glass\utils.lua
 
 # Components

--- a/Glass/compat.lua
+++ b/Glass/compat.lua
@@ -1,0 +1,45 @@
+if not Mixin then
+  function Mixin(object, ...)
+    for i = 1, select('#', ...) do
+      local mixin = select(i, ...)
+      if type(mixin) == "table" then
+        for k, v in pairs(mixin) do
+          object[k] = v
+        end
+      end
+    end
+    return object
+  end
+end
+
+if not C_Timer then
+  C_Timer = {}
+end
+
+if not C_Timer.NewTimer then
+  local waitFrame = CreateFrame("Frame")
+  local waitTable = {}
+
+  waitFrame:SetScript("OnUpdate", function(self, elapsed)
+    for i = #waitTable, 1, -1 do
+      local timer = waitTable[i]
+      timer.delay = timer.delay - elapsed
+      if timer.delay <= 0 then
+        table.remove(waitTable, i)
+        if not timer.cancelled then
+          timer.func()
+        end
+      end
+    end
+  end)
+
+  function C_Timer.NewTimer(delay, func)
+    local timer = {delay = delay, func = func}
+    table.insert(waitTable, timer)
+    return {
+      Cancel = function()
+        timer.cancelled = true
+      end
+    }
+  end
+end

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 #### An immersive and minimalistic chat UI for World of Warcraft
 
+**Note:** This repository contains a 3.3.5a compatible build edited by **Vim**.
+It is based on the original project by [mixxorz](https://github.com/mixxorz/Glass).
+
 [![Demo](https://thumbs.gfycat.com/SkinnyPopularIsabellineshrike-size_restricted.gif)](https://gfycat.com/skinnypopularisabellineshrike)
 
 (Click for slightly higher resolution)
@@ -20,9 +23,8 @@ until the player needs it.
 
 ## Install
 
-Glass is available on [CurseForge](https://www.curseforge.com/wow/addons/glass)
-
-You may also download the latest release on [GitHub](https://github.com/mixxorz/Glass/releases)
+Glass is available on [CurseForge](https://www.curseforge.com/wow/addons/glass).
+This fork targets the Wrath of the Lich King 3.3.5a client. For the official retail version, see the original project on [GitHub](https://github.com/mixxorz/Glass/releases).
 
 ## Commands
 
@@ -72,6 +74,9 @@ Switching these features off will resolve issues with Glass.
 Check the [Issue tracker](https://github.com/mixxorz/Glass/issues) on GitHub
 to see if someone else has already reported your issue. If not, leave a comment
 on [CurseForge](https://www.curseforge.com/wow/addons/glass).
+
+This WotLK edition is maintained by **Vim**. Please refer to the links above for
+the original project and its issue tracker.
 
 ## License
 


### PR DESCRIPTION
## Summary
- add compatibility helpers for older WoW clients
- update Interface version and load compat.lua in TOC
- clarify README that this fork is edited by Vim

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6856d4f2f7c88322b37bd71b77dc1ed2