### PR TITLE
Make addon compatible with 3.3.5a API

### DIFF
--- a/Glass/Components/EditBox.lua
+++ b/Glass/Components/EditBox.lua
@@ -47,7 +47,8 @@ function EditBoxMixin:Init(parent)
   self.header:SetPoint("LEFT", 8, 0)
 
   local bg = self:CreateTexture(nil, "BACKGROUND")
-  bg:SetColorTexture(
+  -- SetColorTexture is unavailable in 3.3.5
+  bg:SetTexture(
     Colors.codGray.r, Colors.codGray.g, Colors.codGray.b, Core.db.profile.editBoxBackgroundOpacity
   )
   bg:SetAllPoints()
@@ -115,7 +116,7 @@ function EditBoxMixin:Init(parent)
     end
 
     if key == "editBoxBackgroundOpacity" then
-      bg:SetColorTexture(
+      bg:SetTexture(
         Colors.codGray.r, Colors.codGray.g, Colors.codGray.b, Core.db.profile.editBoxBackgroundOpacity
       )
     end

--- a/Glass/Components/GradientBackground.lua
+++ b/Glass/Components/GradientBackground.lua
@@ -10,7 +10,8 @@ function GradientBackgroundMixin:SetGradientBackground(leftWidth, rightWidth, co
     self.leftBg = self:CreateTexture(nil, "BACKGROUND")
     self.leftBg:SetPoint("TOPLEFT")
     self.leftBg:SetPoint("BOTTOMLEFT")
-    self.leftBg:SetColorTexture(1, 1, 1, 1)
+    -- SetColorTexture doesn't exist in 3.3.5
+    self.leftBg:SetTexture(1, 1, 1, 1)
   end
   self.leftBg:SetWidth(leftWidth)
   self.leftBg:SetGradientAlpha(
@@ -23,7 +24,7 @@ function GradientBackgroundMixin:SetGradientBackground(leftWidth, rightWidth, co
     self.rightBg = self:CreateTexture(nil, "BACKGROUND")
     self.rightBg:SetPoint("TOPRIGHT")
     self.rightBg:SetPoint("BOTTOMRIGHT")
-    self.rightBg:SetColorTexture(1, 1, 1, 1)
+    self.rightBg:SetTexture(1, 1, 1, 1)
   end
   self.rightBg:SetWidth(rightWidth)
   self.rightBg:SetGradientAlpha(
@@ -37,7 +38,7 @@ function GradientBackgroundMixin:SetGradientBackground(leftWidth, rightWidth, co
     self.centerBg:SetPoint("TOPLEFT", self.leftBg, "TOPRIGHT")
     self.centerBg:SetPoint("BOTTOMRIGHT", self.rightBg, "BOTTOMLEFT")
   end
-  self.centerBg:SetColorTexture(color.r, color.g, color.b, opacity)
+  self.centerBg:SetTexture(color.r, color.g, color.b, opacity)
 end
 
 Core.Components.GradientBackgroundMixin = GradientBackgroundMixin

--- a/Glass/Components/MainContainerFrame.lua
+++ b/Glass/Components/MainContainerFrame.lua
@@ -23,7 +23,8 @@ function MainContainerFrameMixin:Init()
 
   --[===[@debug@
   self.bg = self:CreateTexture(nil, "BACKGROUND")
-  self.bg:SetColorTexture(1, 0, 0, 0)
+  -- SetColorTexture not present in 3.3.5
+  self.bg:SetTexture(1, 0, 0, 0)
   self.bg:SetAllPoints()
   --@end-debug@]===]
 

--- a/Glass/Components/MoverDialog.lua
+++ b/Glass/Components/MoverDialog.lua
@@ -12,7 +12,6 @@ local BackdropTemplateMixin = BackdropTemplateMixin
 local CreateFrame = CreateFrame
 local Mixin = Mixin
 local PlaySound = PlaySound
-local SOUNDKIT = SOUNDKIT
 -- luacheck: pop
 
 function MoverDialogMixin:Init()
@@ -34,8 +33,9 @@ function MoverDialogMixin:Init()
   self:SetPoint("TOP", 0, -50)
   self:Hide()
 
-  self:SetScript("OnShow", function() PlaySound(SOUNDKIT.IG_MAINMENU_OPTION) end)
-  self:SetScript("OnHide", function() PlaySound(SOUNDKIT.GS_TITLE_OPTION_EXIT) end)
+  -- SOUNDKIT constants aren't available in 3.3.5
+  self:SetScript("OnShow", function() PlaySound(852) end) -- IG_MAINMENU_OPTION
+  self:SetScript("OnHide", function() PlaySound(799) end) -- GS_TITLE_OPTION_EXIT
 
   self.header = self:CreateTexture(nil, "ARTWORK")
   self.header:SetTexture("Interface\\DialogFrame\\UI-DialogBox-Header")

--- a/Glass/Components/MoverFrame.lua
+++ b/Glass/Components/MoverFrame.lua
@@ -25,7 +25,8 @@ function MoverFrameMixin:Init()
   self:SetHeight(Core.db.profile.frameHeight + editBoxMargin)
 
   self.bg = self:CreateTexture(nil, "BACKGROUND")
-  self.bg:SetColorTexture(0, 1, 0, 0.5)
+  -- SetColorTexture not available on 3.3.5
+  self.bg:SetTexture(0, 1, 0, 0.5)
   self.bg:SetAllPoints()
 
   self:Hide()

--- a/Glass/Components/ScrollOverlayFrame.lua
+++ b/Glass/Components/ScrollOverlayFrame.lua
@@ -23,18 +23,8 @@ function ScrollOverlayFrame:Init()
     self:SetFadeInDuration(0.3)
     self:SetFadeOutDuration(0.15)
 
-    if self.mask == nil then
-      self.mask = self:CreateMaskTexture()
-    end
-    self.mask:SetTexture("Interface\\Addons\\Glass\\Assets\\overlayMask", "CLAMP", "CLAMPTOBLACKADDITIVE")
-    self.mask:SetSize(16, 64)
-    self.mask:SetPoint("CENTER", 0, -32)
-
+    -- Mask textures were introduced after 3.3.5. Use a simple texture instead.
     self:SetGradientBackground(15, 15, Colors.codGray, overlayOpacity)
-
-    self.leftBg:AddMaskTexture(self.mask)
-    self.centerBg:AddMaskTexture(self.mask)
-    self.rightBg:AddMaskTexture(self.mask)
 
     -- Down arrow icon
     if self.icon == nil then

--- a/Glass/Components/SlidingMessageFrame.lua
+++ b/Glass/Components/SlidingMessageFrame.lua
@@ -169,7 +169,8 @@ function SlidingMessageFrameMixin:Init(chatFrame)
     self.slider.bg = self.slider:CreateTexture(nil, "BACKGROUND")
   end
   self.slider.bg:SetAllPoints()
-  self.slider.bg:SetColorTexture(0, 0, 1, 0)
+  -- SetColorTexture not available in 3.3.5
+  self.slider.bg:SetTexture(0, 0, 1, 0)
 
   -- Pool for the message frames
   if self.messageFramePool == nil then

--- a/libs/AceGUI-3.0/widgets/AceGUIContainer-ScrollFrame.lua
+++ b/libs/AceGUI-3.0/widgets/AceGUIContainer-ScrollFrame.lua
@@ -185,9 +185,10 @@ local function Constructor()
 	-- set the script as the last step, so it doesn't fire yet
 	scrollbar:SetScript("OnValueChanged", ScrollBar_OnScrollValueChanged)
 
-	local scrollbg = scrollbar:CreateTexture(nil, "BACKGROUND")
-	scrollbg:SetAllPoints(scrollbar)
-	scrollbg:SetColorTexture(0, 0, 0, 0.4)
+        local scrollbg = scrollbar:CreateTexture(nil, "BACKGROUND")
+        scrollbg:SetAllPoints(scrollbar)
+        -- SetColorTexture not in 3.3.5
+        scrollbg:SetTexture(0, 0, 0, 0.4)
 
 	--Container Support
 	local content = CreateFrame("Frame", nil, scrollframe)

--- a/libs/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
+++ b/libs/AceGUI-3.0/widgets/AceGUIContainer-TreeGroup.lua
@@ -673,9 +673,10 @@ local function Constructor()
 	scrollbar:SetWidth(16)
 	scrollbar:SetScript("OnValueChanged", OnScrollValueChanged)
 
-	local scrollbg = scrollbar:CreateTexture(nil, "BACKGROUND")
-	scrollbg:SetAllPoints(scrollbar)
-	scrollbg:SetColorTexture(0,0,0,0.4)
+        local scrollbg = scrollbar:CreateTexture(nil, "BACKGROUND")
+        scrollbg:SetAllPoints(scrollbar)
+        -- SetColorTexture not in 3.3.5
+        scrollbg:SetTexture(0,0,0,0.4)
 
 	local border = CreateFrame("Frame", nil, frame, BackdropTemplateMixin and "BackdropTemplate" or nil)
 	border:SetPoint("TOPLEFT", treeframe, "TOPRIGHT")

--- a/libs/AceGUI-3.0/widgets/AceGUIWidget-ColorPicker.lua
+++ b/libs/AceGUI-3.0/widgets/AceGUIWidget-ColorPicker.lua
@@ -147,7 +147,8 @@ local function Constructor()
 	colorSwatch.background = texture
 	texture:SetWidth(16)
 	texture:SetHeight(16)
-	texture:SetColorTexture(1, 1, 1)
+        -- SetColorTexture not present in 3.3.5
+        texture:SetTexture(1, 1, 1)
 	texture:SetPoint("CENTER", colorSwatch)
 	texture:Show()
 

--- a/libs/AceGUI-3.0/widgets/AceGUIWidget-DropDown-Items.lua
+++ b/libs/AceGUI-3.0/widgets/AceGUIWidget-DropDown-Items.lua
@@ -455,7 +455,8 @@ do
 
 		local line = self.frame:CreateTexture(nil, "OVERLAY")
 		line:SetHeight(1)
-		line:SetColorTexture(.5, .5, .5)
+                -- SetColorTexture not available in 3.3.5
+                line:SetTexture(.5, .5, .5)
 		line:SetPoint("LEFT", self.frame, "LEFT", 10, 0)
 		line:SetPoint("RIGHT", self.frame, "RIGHT", -10, 0)
 


### PR DESCRIPTION
## Summary
- use `SetTexture` instead of `SetColorTexture`
- remove mask textures in `ScrollOverlayFrame`
- replace SOUNDKIT constants with numeric IDs
- update AceGUI widgets to avoid `SetColorTexture`

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d63bcea48322ac730ca45c93e61f