### PR TITLE
Fix Battlepet link tooltip check

### DIFF
--- a/EpochGlass/Modules/Hyperlinks.lua
+++ b/EpochGlass/Modules/Hyperlinks.lua
@@ -56,9 +56,11 @@ function Hyperlinks:OnEnable()
 
     if linkTypes[t] then
       if t == "battlepet" then
-        self.state.showingTooltip = BattlePetTooltip
-        GameTooltip:SetOwner(UIParent, "ANCHOR_CURSOR")
-        BattlePetToolTip_ShowLink(text)
+        if BattlePetToolTip_ShowLink and BattlePetTooltip then
+          self.state.showingTooltip = BattlePetTooltip
+          GameTooltip:SetOwner(UIParent, "ANCHOR_CURSOR")
+          BattlePetToolTip_ShowLink(text)
+        end
       else
         self.state.showingTooltip = GameTooltip
         ShowUIPanel(GameTooltip)


### PR DESCRIPTION
## Summary
- avoid errors if BattlePet tooltip APIs are missing

## Testing
- `luacheck --version` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685803e43ea48322af3c4236652e6c36