### PR TITLE
Fix Battlepet link tooltip check

### DIFF
--- a/EpochGlass/Modules/Hyperlinks.lua
+++ b/EpochGlass/Modules/Hyperlinks.lua
@@ -7,14 +7,10 @@ local HYPERLINK_CLICK = Constants.EVENTS.HYPERLINK_CLICK
 local HYPERLINK_ENTER = Constants.EVENTS.HYPERLINK_ENTER
 local HYPERLINK_LEAVE = Constants.EVENTS.HYPERLINK_LEAVE
 
--- luacheck: push ignore 113
-local BattlePetToolTip_ShowLink = BattlePetToolTip_ShowLink
-local BattlePetTooltip = BattlePetTooltip
 local GameTooltip = GameTooltip
 local ShowUIPanel = ShowUIPanel
 local UIParent = UIParent
 local strsplit = strsplit
--- luacheck: pop
 
 local linkTypes = {
   item = true,
@@ -23,7 +19,6 @@ local linkTypes = {
   quest = true,
   achievement = true,
   currency = true,
-  battlepet = true,
 }
 
 function Hyperlinks:OnInitialize()
@@ -51,21 +46,15 @@ function Hyperlinks:OnEnable()
   end)
 
   Core:Subscribe(HYPERLINK_ENTER, function (payload)
-    local link, text = unpack(payload)
+    local link = payload[1]
     local t = string.match(link, "^(.-):")
 
     if linkTypes[t] then
-      if t == "battlepet" then
-        self.state.showingTooltip = BattlePetTooltip
-        GameTooltip:SetOwner(UIParent, "ANCHOR_CURSOR")
-        BattlePetToolTip_ShowLink(text)
-      else
-        self.state.showingTooltip = GameTooltip
-        ShowUIPanel(GameTooltip)
-        GameTooltip:SetOwner(UIParent, "ANCHOR_CURSOR")
-        GameTooltip:SetHyperlink(link)
-        GameTooltip:Show()
-      end
+      self.state.showingTooltip = GameTooltip
+      ShowUIPanel(GameTooltip)
+      GameTooltip:SetOwner(UIParent, "ANCHOR_CURSOR")
+      GameTooltip:SetHyperlink(link)
+      GameTooltip:Show()
     end
   end)
 


### PR DESCRIPTION
## Summary
- avoid errors if BattlePet tooltip APIs are missing
- remove battlepet tooltip code for WotLK compatibility
- minor cleanup in hyperlink handler

## Testing
- `luacheck --version` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685803e43ea48322af3c4236652e6c36