### PR TITLE
Ensure compatibility with Lua 3.3.5a

### DIFF
--- a/EpochGlass/compat.lua
+++ b/EpochGlass/compat.lua
@@ -82,57 +82,6 @@ if not CreateObjectPool then
   local ObjectPoolMixin = {}
   ObjectPoolMixin.__index = ObjectPoolMixin
 
-  local function getIndex(tbl, object)
-    for i, v in ipairs(tbl) do
-      if v == object then
-        return i
-      end
-    end
-    return nil
-  end
-
-  function ObjectPoolMixin:Acquire()
-    local object = table.remove(self.inactiveObjects)
-    if not object then
-      object = self.creationFunc()
-    end
-    table.insert(self.activeObjects, object)
-    return object
-  end
-
-  function ObjectPoolMixin:Release(object)
-    local index = getIndex(self.activeObjects, object)
-    if index then
-      table.remove(self.activeObjects, index)
-      if self.resetterFunc then
-        self.resetterFunc(self, object)
-      end
-      table.insert(self.inactiveObjects, object)
-    end
-  end
-
-  function ObjectPoolMixin:ReleaseAll()
-    for i = #self.activeObjects, 1, -1 do
-      self:Release(self.activeObjects[i])
-    end
-  end
-
-  function CreateObjectPool(creationFunc, resetterFunc)
-    local pool = {
-      creationFunc = creationFunc,
-      resetterFunc = resetterFunc,
-      activeObjects = {},
-      inactiveObjects = {},
-    }
-    return setmetatable(pool, ObjectPoolMixin)
-  end
-end
-
--- Polyfill for CreateObjectPool (not present in 3.3.5a)
-if not CreateObjectPool then
-  local ObjectPoolMixin = {}
-  ObjectPoolMixin.__index = ObjectPoolMixin
-
   function ObjectPoolMixin:Acquire()
     local object
     if #self.inactiveObjects > 0 then
@@ -173,4 +122,15 @@ if not CreateObjectPool then
     }
     return setmetatable(pool, ObjectPoolMixin)
   end
+end
+
+if CreateFrame then
+  local fs = CreateFrame("Frame"):CreateFontString()
+  local meta = getmetatable(fs)
+  if meta and meta.__index and not meta.__index.SetIndentedWordWrap then
+    function meta.__index:SetIndentedWordWrap()
+      -- Not supported on 3.3.5a
+    end
+  end
+  fs:GetParent():Hide()
 end


### PR DESCRIPTION
## Summary
- remove duplicate CreateObjectPool polyfill
- stub `SetIndentedWordWrap` for older clients

## Testing
- `luac -p EpochGlass/compat.lua`
- `while read -r file; do luac -p "$file"; done < lua_files.txt` *(all Lua files compile)*

------
https://chatgpt.com/codex/tasks/task_e_6858277be33c8322a3553d9565256884